### PR TITLE
fix(package) fix publish task

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "repository": "ssh://git@github.com/uncovertruth/styleguide.git",
   "scripts": {
     "precommit": "lint-staged",
-    "release": "lerna exec --bail=false -- can-npm-publish && npm publish",
+    "release": "lerna exec --bail=false -- 'can-npm-publish && npm publish'",
     "test": "lerna run test",
     "version": "lerna publish --skip-npm --skip-git"
   },


### PR DESCRIPTION
```
⟩ lerna exec -- echo 'a' && echo 'b'
fish: Unsupported use of '&&'. In fish, please use 'COMMAND; and COMMAND'.
lerna exec -- echo 'a' && echo 'b'
                        ^

~/src/github.com/uncovertruth/styleguide · (master)
⟩ lerna exec -- "echo 'a' && echo 'b'"
lerna info version 2.9.0
a
b
a
b
a
b
a
b
a
b
a
b
a
b
a
b
a
b
```