### PR TITLE
chore(packages/tslint-config) Added tslint:latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.envrc
 .textlintcache
 .changelog/
 packages/**/yarn.lock

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bump": "lerna publish --skip-npm --skip-git && lerna-changelog",
     "precommit": "lint-staged",
     "release": "lerna exec --bail=false -- 'can-npm-publish && npm publish'",
-    "test": "lerna run test"
+    "test": "lerna run test --parallel"
   },
   "workspaces": [
     "packages/*"

--- a/packages/tslint-config/tslint.json
+++ b/packages/tslint-config/tslint.json
@@ -1,6 +1,10 @@
 {
-  "extends": "tslint-config-standard",
+  "extends": [
+    "tslint:latest",
+    "tslint-config-standard"
+  ],
   "rules": {
-    "ordered-imports": true
+    "ordered-imports": true,
+    "no-implicit-dependencies": false
   }
 }


### PR DESCRIPTION
skip `no-implicit-dependencies` 

because

- we use tslint for tests
- If you fail to install, you will be noticed by type definition